### PR TITLE
feat: add testnet support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,8 @@
 # different scripts.
 
 # General configuration
+# NOTE: DATA_DIR must be an absolute path (no variables like $HOME or $(HOME))
+# Docker Compose does not expand variables in .env files
 DATA_DIR=/media/data-disk
 
 #########

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ zebrad.toml
 zaino.toml
 .env
 zcash.conf
+
+# Testnet generated configs
+zebrad.testnet.toml
+zaino.testnet.toml
+zcash.testnet.conf

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,9 @@ zcash.conf
 zebrad.toml
 zaino.toml
 .env
+zebrad.testnet.toml
+zaino.testnet.toml
+zcash.testnet.conf
 
 # Grafana dashboards (complex JSON, keep as-is)
 grafana/dashboards/

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ setup: ## Create all required directories and set permissions
 	@echo "Using DATA_DIR: $(DATA_DIR)"
 
 	@echo "Creating Zcash service directories..."
-	$(SUDO) mkdir -p $(DATA_DIR)/zcashd_data
-	$(SUDO) mkdir -p $(DATA_DIR)/lightwalletd_db_volume
+	mkdir -p $(DATA_DIR)/zcashd_data
+	mkdir -p $(DATA_DIR)/lightwalletd_db_volume
 	$(if $(SUDO),$(SUDO) chown 2002 $(DATA_DIR)/lightwalletd_db_volume)
 
 	@echo "Setting up zcash.conf file (updating if necessary)"
@@ -42,7 +42,7 @@ setup: ## Create all required directories and set permissions
 	$(SED) -i "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.conf; \
 	$(SED) -i "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.conf; \
 	echo "Created new zcash.conf file with proper credentials. Copying in $(DATA_DIR)/zcashd/zcash.conf"; \
-	$(SUDO) cp -f zcash.conf $(DATA_DIR)/zcashd_data/zcash.conf
+	cp -f zcash.conf $(DATA_DIR)/zcashd_data/zcash.conf
 
 	@echo "Setting up zebrad.toml (updating if necessary)"
 	@cp -f zebrad.toml.template zebrad.toml
@@ -55,22 +55,22 @@ setup: ## Create all required directories and set permissions
 	$(SED) -i "s/ZEBRA_RPC_PORT/$(ZEBRA_RPC_PORT)/g" zaino.toml
 
 	@echo "Creating Caddy directories..."
-	$(SUDO) mkdir -p $(DATA_DIR)/caddy_data
-	$(SUDO) mkdir -p $(DATA_DIR)/caddy_config
+	mkdir -p $(DATA_DIR)/caddy_data
+	mkdir -p $(DATA_DIR)/caddy_config
 
 	@echo "Creating monitoring directories..."
-	$(SUDO) mkdir -p $(DATA_DIR)/prometheus_data
-	$(SUDO) mkdir -p $(DATA_DIR)/grafana_data
+	mkdir -p $(DATA_DIR)/prometheus_data
+	mkdir -p $(DATA_DIR)/grafana_data
 	$(if $(SUDO),$(SUDO) chown 65534:65534 $(DATA_DIR)/prometheus_data)
 	$(if $(SUDO),$(SUDO) chown -R 472:0 $(DATA_DIR)/grafana_data)
 	$(if $(SUDO),$(SUDO) chmod -R 755 $(DATA_DIR)/grafana_data)
 
 	@echo "Creating zebrad directories..."
-	$(SUDO) mkdir -p $(DATA_DIR)/zebrad-data
+	mkdir -p $(DATA_DIR)/zebrad-data
 	$(if $(SUDO),$(SUDO) chown -R 2001:2001 $(DATA_DIR)/zebrad-data)
 
 	@echo "Creating zaino directories..."
-	$(SUDO) mkdir -p $(DATA_DIR)/zaino-data
+	mkdir -p $(DATA_DIR)/zaino-data
 	$(if $(SUDO),$(SUDO) chown -R 2003:2003 $(DATA_DIR)/zaino-data)
 
 	@echo "Creating Docker network..."
@@ -115,10 +115,10 @@ start-monitoring: ## Start monitoring stack (Prometheus, Node Exporter, Grafana)
 .PHONY: setup-testnet
 setup-testnet: ## Create testnet directories and config files
 	@echo "Setting up testnet directories..."
-	$(SUDO) mkdir -p $(DATA_DIR)/zcashd_testnet_data
-	$(SUDO) mkdir -p $(DATA_DIR)/lightwalletd_testnet_db
-	$(SUDO) mkdir -p $(DATA_DIR)/zebrad-testnet-cache
-	$(SUDO) mkdir -p $(DATA_DIR)/zaino-testnet-data
+	mkdir -p $(DATA_DIR)/zcashd_testnet_data
+	mkdir -p $(DATA_DIR)/lightwalletd_testnet_db
+	mkdir -p $(DATA_DIR)/zebrad-testnet-cache
+	mkdir -p $(DATA_DIR)/zaino-testnet-data
 	$(if $(SUDO),$(SUDO) chown 2002 $(DATA_DIR)/lightwalletd_testnet_db)
 	$(if $(SUDO),$(SUDO) chown -R 2001:2001 $(DATA_DIR)/zebrad-testnet-cache)
 	$(if $(SUDO),$(SUDO) chown -R 2003:2003 $(DATA_DIR)/zaino-testnet-data)
@@ -127,7 +127,7 @@ setup-testnet: ## Create testnet directories and config files
 	@cp -f zcash.conf.testnet.template zcash.testnet.conf
 	$(SED) -i "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.testnet.conf
 	$(SED) -i "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.testnet.conf
-	$(SUDO) cp -f zcash.testnet.conf $(DATA_DIR)/zcashd_testnet_data/zcash.conf
+	cp -f zcash.testnet.conf $(DATA_DIR)/zcashd_testnet_data/zcash.conf
 
 	@cp -f zebrad.toml.testnet.template zebrad.testnet.toml
 	$(SED) -i "s/ZEBRA_P2P_PORT/18233/g" zebrad.testnet.toml

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,57 @@ start-monitoring: ## Start monitoring stack (Prometheus, Node Exporter, Grafana)
 	@echo "You can run make check-zcash-exporter to verify that data are fetched from zcash"
 	@echo "You can visit http://localhost:3000/login to access Grafana and monitor the health of the node"
 
+.PHONY: setup-testnet
+setup-testnet: ## Create testnet directories and config files
+	@echo "Setting up testnet directories..."
+	sudo mkdir -p $(DATA_DIR)/zcashd_testnet_data
+	sudo mkdir -p $(DATA_DIR)/lightwalletd_testnet_db
+	sudo mkdir -p $(DATA_DIR)/zebrad-testnet-cache
+	sudo mkdir -p $(DATA_DIR)/zaino-testnet-data
+	sudo chown 2002 $(DATA_DIR)/lightwalletd_testnet_db
+	sudo chown -R 2001:2001 $(DATA_DIR)/zebrad-testnet-cache
+	sudo chown -R 2003:2003 $(DATA_DIR)/zaino-testnet-data
+
+	@echo "Setting up testnet config files..."
+	@cp -f zcash.conf.testnet.template zcash.testnet.conf
+	sed -i "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.testnet.conf
+	sed -i "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.testnet.conf
+	sudo cp -f zcash.testnet.conf $(DATA_DIR)/zcashd_testnet_data/zcash.conf
+
+	@cp -f zebrad.toml.testnet.template zebrad.testnet.toml
+	sed -i "s/ZEBRA_P2P_PORT/18233/g" zebrad.testnet.toml
+	sed -i "s/ZEBRA_RPC_PORT/18232/g" zebrad.testnet.toml
+
+	@cp -f zaino.toml.testnet.template zaino.testnet.toml
+	sed -i "s/ZAINO_GRPC_PORT/8137/g" zaino.testnet.toml
+	sed -i "s/ZEBRA_RPC_PORT/8232/g" zaino.testnet.toml
+
+	@echo "Testnet setup complete!"
+
+.PHONY: start-zcash-testnet
+start-zcash-testnet: ## Start Zcash testnet services (zcashd-testnet and lightwalletd-testnet)
+	@echo "Starting Zcash testnet services..."
+	docker-compose -f docker-compose.zcash.testnet.yml up -d
+	@echo "Zcash testnet services started successfully"
+
+.PHONY: start-zebra-testnet
+start-zebra-testnet: ## Start Zebra testnet services (zebra-testnet and zaino-testnet)
+	@echo "Starting Zebra testnet services..."
+	docker-compose -f docker-compose.zebra.testnet.yml up -d
+	@echo "Zebra testnet services started successfully"
+
+.PHONY: stop-zcash-testnet
+stop-zcash-testnet: ## Stop Zcash testnet services
+	@echo "Stopping Zcash testnet services..."
+	docker-compose -f docker-compose.zcash.testnet.yml down
+	@echo "Zcash testnet services stopped successfully"
+
+.PHONY: stop-zebra-testnet
+stop-zebra-testnet: ## Stop Zebra testnet services
+	@echo "Stopping Zebra testnet services..."
+	docker-compose -f docker-compose.zebra.testnet.yml down
+	@echo "Zebra testnet services stopped successfully"
+
 .PHONY: stop-all
 stop-all: ## Stop all services
 	@echo "Stopping all services..."

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ DATA_DIR ?= /media/data-disk
 # Set SUDO to empty for local development: make setup SUDO=
 SUDO ?= sudo
 
+# macOS sed requires '' for in-place, GNU sed does not
+SEDI := $(shell if sed --version 2>/dev/null | grep -q GNU; then echo 'sed -i'; else echo 'sed -i ""'; fi)
+
 .PHONY: help
 help: ## Show this help message
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
@@ -24,25 +27,25 @@ setup: ## Create all required directories and set permissions
 	@echo "Creating Zcash service directories..."
 	$(SUDO) mkdir -p $(DATA_DIR)/zcashd_data
 	$(SUDO) mkdir -p $(DATA_DIR)/lightwalletd_db_volume
-	$(SUDO) chown 2002 $(DATA_DIR)/lightwalletd_db_volume
+	$(if $(SUDO),$(SUDO) chown 2002 $(DATA_DIR)/lightwalletd_db_volume)
 
 	@echo "Setting up zcash.conf file (updating if necessary)"
 	cp zcash.conf.template zcash.conf; \
-	sed -i "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.conf; \
-	sed -i "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.conf; \
-	sed -i "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.conf; \
+	$(SEDI) "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.conf; \
+	$(SEDI) "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.conf; \
+	$(SEDI) "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.conf; \
 	echo "Created new zcash.conf file with proper credentials. Copying in $(DATA_DIR)/zcashd/zcash.conf"; \
 	$(SUDO) cp -f zcash.conf $(DATA_DIR)/zcashd_data/zcash.conf
 
 	@echo "Setting up zebrad.toml (updating if necessary)"
 	@cp -f zebrad.toml.template zebrad.toml
-	sed -i "s/ZEBRA_P2P_PORT/$(ZEBRA_P2P_PORT)/g" zebrad.toml
-	sed -i "s/ZEBRA_RPC_PORT/$(ZEBRA_RPC_PORT)/g" zebrad.toml
+	$(SEDI) "s/ZEBRA_P2P_PORT/$(ZEBRA_P2P_PORT)/g" zebrad.toml
+	$(SEDI) "s/ZEBRA_RPC_PORT/$(ZEBRA_RPC_PORT)/g" zebrad.toml
 
 	@echo "Setting up zaino.toml (updating if necessary)"
 	@cp -f zaino.toml.template zaino.toml
-	sed -i "s/ZAINO_GRPC_PORT/$(ZAINO_GRPC_PORT)/g" zaino.toml
-	sed -i "s/ZEBRA_RPC_PORT/$(ZEBRA_RPC_PORT)/g" zaino.toml
+	$(SEDI) "s/ZAINO_GRPC_PORT/$(ZAINO_GRPC_PORT)/g" zaino.toml
+	$(SEDI) "s/ZEBRA_RPC_PORT/$(ZEBRA_RPC_PORT)/g" zaino.toml
 
 	@echo "Creating Caddy directories..."
 	$(SUDO) mkdir -p $(DATA_DIR)/caddy_data
@@ -51,17 +54,17 @@ setup: ## Create all required directories and set permissions
 	@echo "Creating monitoring directories..."
 	$(SUDO) mkdir -p $(DATA_DIR)/prometheus_data
 	$(SUDO) mkdir -p $(DATA_DIR)/grafana_data
-	$(SUDO) chown 65534:65534 $(DATA_DIR)/prometheus_data
-	$(SUDO) chown -R 472:0 $(DATA_DIR)/grafana_data
-	$(SUDO) chmod -R 755 $(DATA_DIR)/grafana_data
+	$(if $(SUDO),$(SUDO) chown 65534:65534 $(DATA_DIR)/prometheus_data)
+	$(if $(SUDO),$(SUDO) chown -R 472:0 $(DATA_DIR)/grafana_data)
+	$(if $(SUDO),$(SUDO) chmod -R 755 $(DATA_DIR)/grafana_data)
 
 	@echo "Creating zebrad directories..."
 	$(SUDO) mkdir -p $(DATA_DIR)/zebrad-data
-	$(SUDO) chown -R 2001:2001 $(DATA_DIR)/zebrad-data
+	$(if $(SUDO),$(SUDO) chown -R 2001:2001 $(DATA_DIR)/zebrad-data)
 
 	@echo "Creating zaino directories..."
 	$(SUDO) mkdir -p $(DATA_DIR)/zaino-data
-	$(SUDO) chown -R 2003:2003 $(DATA_DIR)/zaino-data
+	$(if $(SUDO),$(SUDO) chown -R 2003:2003 $(DATA_DIR)/zaino-data)
 
 	@echo "Creating Docker network..."
 	-docker network create zcash-network 2>/dev/null || true
@@ -109,23 +112,23 @@ setup-testnet: ## Create testnet directories and config files
 	$(SUDO) mkdir -p $(DATA_DIR)/lightwalletd_testnet_db
 	$(SUDO) mkdir -p $(DATA_DIR)/zebrad-testnet-cache
 	$(SUDO) mkdir -p $(DATA_DIR)/zaino-testnet-data
-	$(SUDO) chown 2002 $(DATA_DIR)/lightwalletd_testnet_db
-	$(SUDO) chown -R 2001:2001 $(DATA_DIR)/zebrad-testnet-cache
-	$(SUDO) chown -R 2003:2003 $(DATA_DIR)/zaino-testnet-data
+	$(if $(SUDO),$(SUDO) chown 2002 $(DATA_DIR)/lightwalletd_testnet_db)
+	$(if $(SUDO),$(SUDO) chown -R 2001:2001 $(DATA_DIR)/zebrad-testnet-cache)
+	$(if $(SUDO),$(SUDO) chown -R 2003:2003 $(DATA_DIR)/zaino-testnet-data)
 
 	@echo "Setting up testnet config files..."
 	@cp -f zcash.conf.testnet.template zcash.testnet.conf
-	sed -i "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.testnet.conf
-	sed -i "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.testnet.conf
+	$(SEDI) "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.testnet.conf
+	$(SEDI) "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.testnet.conf
 	$(SUDO) cp -f zcash.testnet.conf $(DATA_DIR)/zcashd_testnet_data/zcash.conf
 
 	@cp -f zebrad.toml.testnet.template zebrad.testnet.toml
-	sed -i "s/ZEBRA_P2P_PORT/18233/g" zebrad.testnet.toml
-	sed -i "s/ZEBRA_RPC_PORT/18232/g" zebrad.testnet.toml
+	$(SEDI) "s/ZEBRA_P2P_PORT/18233/g" zebrad.testnet.toml
+	$(SEDI) "s/ZEBRA_RPC_PORT/18232/g" zebrad.testnet.toml
 
 	@cp -f zaino.toml.testnet.template zaino.testnet.toml
-	sed -i "s/ZAINO_GRPC_PORT/8137/g" zaino.testnet.toml
-	sed -i "s/ZEBRA_RPC_PORT/8232/g" zaino.testnet.toml
+	$(SEDI) "s/ZAINO_GRPC_PORT/8137/g" zaino.testnet.toml
+	$(SEDI) "s/ZEBRA_RPC_PORT/8232/g" zaino.testnet.toml
 
 	@echo "Testnet setup complete!"
 
@@ -300,7 +303,7 @@ update-zaino-commit: ## Update docker-compose to use a specific Zaino commit (CO
 		exit 1; \
 	fi
 	@echo "Updating docker-compose.zebra.yml to use Zaino commit $(COMMIT)..."
-	@sed -i 's|image: zingolabs/zaino:.*|image: zingolabs/zaino:$(COMMIT)  # Build with '\''make build-zaino-commit COMMIT=$(COMMIT)'\''|' docker-compose.zebra.yml
+	@$(SEDI) 's|image: zingolabs/zaino:.*|image: zingolabs/zaino:$(COMMIT)  # Build with '\''make build-zaino-commit COMMIT=$(COMMIT)'\''|' docker-compose.zebra.yml
 	@echo "Docker Compose configuration updated to use Zaino commit $(COMMIT)."
 	@echo "Run 'make start-zebra' to apply the changes."
 
@@ -380,9 +383,9 @@ clean-monitoring: ## Reset Prometheus and Grafana data (WARNING: destructive!)
 	@echo "Recreating monitoring directories with proper permissions..."
 	$(SUDO) mkdir -p $(DATA_DIR)/prometheus_data
 	$(SUDO) mkdir -p $(DATA_DIR)/grafana_data
-	$(SUDO) chown 65534:65534 $(DATA_DIR)/prometheus_data
-	$(SUDO) chown -R 472:0 $(DATA_DIR)/grafana_data
-	$(SUDO) chmod -R 755 $(DATA_DIR)/grafana_data
+	$(if $(SUDO),$(SUDO) chown 65534:65534 $(DATA_DIR)/prometheus_data)
+	$(if $(SUDO),$(SUDO) chown -R 472:0 $(DATA_DIR)/grafana_data)
+	$(if $(SUDO),$(SUDO) chmod -R 755 $(DATA_DIR)/grafana_data)
 
 	@echo "Monitoring data has been cleaned."
 	@echo "You can restart the monitoring services with 'make start-monitoring'"

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ endif
 # Default values if not defined in .env
 DATA_DIR ?= /media/data-disk
 
+# Set SUDO to empty for local development: make setup SUDO=
+SUDO ?= sudo
+
 .PHONY: help
 help: ## Show this help message
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
@@ -19,9 +22,9 @@ setup: ## Create all required directories and set permissions
 	@echo "Using DATA_DIR: $(DATA_DIR)"
 
 	@echo "Creating Zcash service directories..."
-	sudo mkdir -p $(DATA_DIR)/zcashd_data
-	sudo mkdir -p $(DATA_DIR)/lightwalletd_db_volume
-	sudo chown 2002 $(DATA_DIR)/lightwalletd_db_volume
+	$(SUDO) mkdir -p $(DATA_DIR)/zcashd_data
+	$(SUDO) mkdir -p $(DATA_DIR)/lightwalletd_db_volume
+	$(SUDO) chown 2002 $(DATA_DIR)/lightwalletd_db_volume
 
 	@echo "Setting up zcash.conf file (updating if necessary)"
 	cp zcash.conf.template zcash.conf; \
@@ -29,7 +32,7 @@ setup: ## Create all required directories and set permissions
 	sed -i "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.conf; \
 	sed -i "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.conf; \
 	echo "Created new zcash.conf file with proper credentials. Copying in $(DATA_DIR)/zcashd/zcash.conf"; \
-	sudo cp -f zcash.conf $(DATA_DIR)/zcashd_data/zcash.conf
+	$(SUDO) cp -f zcash.conf $(DATA_DIR)/zcashd_data/zcash.conf
 
 	@echo "Setting up zebrad.toml (updating if necessary)"
 	@cp -f zebrad.toml.template zebrad.toml
@@ -42,23 +45,23 @@ setup: ## Create all required directories and set permissions
 	sed -i "s/ZEBRA_RPC_PORT/$(ZEBRA_RPC_PORT)/g" zaino.toml
 
 	@echo "Creating Caddy directories..."
-	sudo mkdir -p $(DATA_DIR)/caddy_data
-	sudo mkdir -p $(DATA_DIR)/caddy_config
+	$(SUDO) mkdir -p $(DATA_DIR)/caddy_data
+	$(SUDO) mkdir -p $(DATA_DIR)/caddy_config
 
 	@echo "Creating monitoring directories..."
-	sudo mkdir -p $(DATA_DIR)/prometheus_data
-	sudo mkdir -p $(DATA_DIR)/grafana_data
-	sudo chown 65534:65534 $(DATA_DIR)/prometheus_data
-	sudo chown -R 472:0 $(DATA_DIR)/grafana_data
-	sudo chmod -R 755 $(DATA_DIR)/grafana_data
+	$(SUDO) mkdir -p $(DATA_DIR)/prometheus_data
+	$(SUDO) mkdir -p $(DATA_DIR)/grafana_data
+	$(SUDO) chown 65534:65534 $(DATA_DIR)/prometheus_data
+	$(SUDO) chown -R 472:0 $(DATA_DIR)/grafana_data
+	$(SUDO) chmod -R 755 $(DATA_DIR)/grafana_data
 
 	@echo "Creating zebrad directories..."
-	sudo mkdir -p $(DATA_DIR)/zebrad-data
-	sudo chown -R 2001:2001 $(DATA_DIR)/zebrad-data
+	$(SUDO) mkdir -p $(DATA_DIR)/zebrad-data
+	$(SUDO) chown -R 2001:2001 $(DATA_DIR)/zebrad-data
 
 	@echo "Creating zaino directories..."
-	sudo mkdir -p $(DATA_DIR)/zaino-data
-	sudo chown -R 2003:2003 $(DATA_DIR)/zaino-data
+	$(SUDO) mkdir -p $(DATA_DIR)/zaino-data
+	$(SUDO) chown -R 2003:2003 $(DATA_DIR)/zaino-data
 
 	@echo "Creating Docker network..."
 	-docker network create zcash-network 2>/dev/null || true
@@ -102,19 +105,19 @@ start-monitoring: ## Start monitoring stack (Prometheus, Node Exporter, Grafana)
 .PHONY: setup-testnet
 setup-testnet: ## Create testnet directories and config files
 	@echo "Setting up testnet directories..."
-	sudo mkdir -p $(DATA_DIR)/zcashd_testnet_data
-	sudo mkdir -p $(DATA_DIR)/lightwalletd_testnet_db
-	sudo mkdir -p $(DATA_DIR)/zebrad-testnet-cache
-	sudo mkdir -p $(DATA_DIR)/zaino-testnet-data
-	sudo chown 2002 $(DATA_DIR)/lightwalletd_testnet_db
-	sudo chown -R 2001:2001 $(DATA_DIR)/zebrad-testnet-cache
-	sudo chown -R 2003:2003 $(DATA_DIR)/zaino-testnet-data
+	$(SUDO) mkdir -p $(DATA_DIR)/zcashd_testnet_data
+	$(SUDO) mkdir -p $(DATA_DIR)/lightwalletd_testnet_db
+	$(SUDO) mkdir -p $(DATA_DIR)/zebrad-testnet-cache
+	$(SUDO) mkdir -p $(DATA_DIR)/zaino-testnet-data
+	$(SUDO) chown 2002 $(DATA_DIR)/lightwalletd_testnet_db
+	$(SUDO) chown -R 2001:2001 $(DATA_DIR)/zebrad-testnet-cache
+	$(SUDO) chown -R 2003:2003 $(DATA_DIR)/zaino-testnet-data
 
 	@echo "Setting up testnet config files..."
 	@cp -f zcash.conf.testnet.template zcash.testnet.conf
 	sed -i "s/LIGHTWALLETD_RPC_USER/$(LIGHTWALLETD_RPC_USER)/g" zcash.testnet.conf
 	sed -i "s/LIGHTWALLETD_RPC_PASSWORD/$(LIGHTWALLETD_RPC_PASSWORD)/g" zcash.testnet.conf
-	sudo cp -f zcash.testnet.conf $(DATA_DIR)/zcashd_testnet_data/zcash.conf
+	$(SUDO) cp -f zcash.testnet.conf $(DATA_DIR)/zcashd_testnet_data/zcash.conf
 
 	@cp -f zebrad.toml.testnet.template zebrad.testnet.toml
 	sed -i "s/ZEBRA_P2P_PORT/18233/g" zebrad.testnet.toml
@@ -320,8 +323,8 @@ clean-zcash: ## Remove Zcash containers and data volumes (WARNING: destructive!)
 	@echo "Revoming zcash services, including the directories"
 	docker-compose -f docker-compose.zcash.yml down -v
 	@echo "Delete Zcash directories..."
-	sudo rm -rf $(DATA_DIR)/zcashd_data
-	sudo rm -rf $(DATA_DIR)/lightwalletd_db_volume
+	$(SUDO) rm -rf $(DATA_DIR)/zcashd_data
+	$(SUDO) rm -rf $(DATA_DIR)/lightwalletd_db_volume
 
 .PHONY: clean-zaino
 clean-zaino: ## Remove Zaino Docker image and build directory
@@ -369,17 +372,17 @@ clean-monitoring: ## Reset Prometheus and Grafana data (WARNING: destructive!)
 	docker-compose -f docker-compose.monitoring.yml down
 
 	@echo "Removing Prometheus data..."
-	sudo rm -rf $(DATA_DIR)/prometheus_data/*
+	$(SUDO) rm -rf $(DATA_DIR)/prometheus_data/*
 
 	@echo "Removing Grafana data..."
-	sudo rm -rf $(DATA_DIR)/grafana_data/*
+	$(SUDO) rm -rf $(DATA_DIR)/grafana_data/*
 
 	@echo "Recreating monitoring directories with proper permissions..."
-	sudo mkdir -p $(DATA_DIR)/prometheus_data
-	sudo mkdir -p $(DATA_DIR)/grafana_data
-	sudo chown 65534:65534 $(DATA_DIR)/prometheus_data
-	sudo chown -R 472:0 $(DATA_DIR)/grafana_data
-	sudo chmod -R 755 $(DATA_DIR)/grafana_data
+	$(SUDO) mkdir -p $(DATA_DIR)/prometheus_data
+	$(SUDO) mkdir -p $(DATA_DIR)/grafana_data
+	$(SUDO) chown 65534:65534 $(DATA_DIR)/prometheus_data
+	$(SUDO) chown -R 472:0 $(DATA_DIR)/grafana_data
+	$(SUDO) chmod -R 755 $(DATA_DIR)/grafana_data
 
 	@echo "Monitoring data has been cleaned."
 	@echo "You can restart the monitoring services with 'make start-monitoring'"

--- a/Makefile
+++ b/Makefile
@@ -79,32 +79,32 @@ setup: ## Create all required directories and set permissions
 	@echo "Setup complete! You can now start services with 'make start-all'"
 
 .PHONY: start-all
-start-all: ## Start all services (Zcash, Caddy, and monitoring)
+start-all: setup ## Start all services (Zcash, Caddy, and monitoring)
 	@echo "Starting all services (zcash, caddy, monitoring)..."
 	docker-compose -f docker-compose.zcash.yml -f docker-compose.caddy.yml -f docker-compose.monitoring.yml up -d
 	@echo "All services started successfully"
 
 .PHONY: start-zcash
-start-zcash: ## Start Zcash services only (zcashd and lightwalletd)
+start-zcash: setup ## Start Zcash services only (zcashd and lightwalletd)
 	@echo "Starting Zcash services (zcashd + lightwalletd)..."
 	docker-compose -f docker-compose.zcash.yml up -d
 	@echo "Zcash services started successfully"
 
 .PHONY: start-zebra
-start-zebra: ## Start Zebra services only (zebra and zaino)
+start-zebra: setup ## Start Zebra services only (zebra and zaino)
 	@echo "Starting Zebra (zebrad + zaino) services..."
 	@echo "zebrad starts first, and zaino container might restart multiple times until zebrad is ready"
 	docker-compose -f docker-compose.zebra.yml up -d
 	@echo "Zebra services started successfully"
 
 .PHONY: start-caddy
-start-caddy: ## Start Caddy web server only
+start-caddy: setup ## Start Caddy web server only
 	@echo "Starting Caddy web server..."
 	docker-compose -f docker-compose.caddy.yml up -d
 	@echo "Caddy web server started successfully"
 
 .PHONY: start-monitoring
-start-monitoring: ## Start monitoring stack (Prometheus, Node Exporter, Grafana)
+start-monitoring: setup ## Start monitoring stack (Prometheus, Node Exporter, Grafana)
 	@echo "Starting monitoring stack (Prometheus, Zcashd exporter, Node exporter, Grafana)..."
 	docker-compose -f docker-compose.monitoring.yml pull
 	docker-compose -f docker-compose.monitoring.yml up -d
@@ -140,13 +140,13 @@ setup-testnet: ## Create testnet directories and config files
 	@echo "Testnet setup complete!"
 
 .PHONY: start-zcash-testnet
-start-zcash-testnet: ## Start Zcash testnet services (zcashd-testnet and lightwalletd-testnet)
+start-zcash-testnet: setup-testnet ## Start Zcash testnet services (zcashd-testnet and lightwalletd-testnet)
 	@echo "Starting Zcash testnet services..."
 	docker-compose -f docker-compose.zcash.testnet.yml up -d
 	@echo "Zcash testnet services started successfully"
 
 .PHONY: start-zebra-testnet
-start-zebra-testnet: ## Start Zebra testnet services (zebra-testnet and zaino-testnet)
+start-zebra-testnet: setup-testnet ## Start Zebra testnet services (zebra-testnet and zaino-testnet)
 	@echo "Starting Zebra testnet services..."
 	docker-compose -f docker-compose.zebra.testnet.yml up -d
 	@echo "Zebra testnet services started successfully"

--- a/docker-compose.zcash.testnet.yml
+++ b/docker-compose.zcash.testnet.yml
@@ -1,0 +1,37 @@
+# Zcash Testnet Configuration
+
+services:
+  zcashd-testnet:
+    image: electriccoinco/zcashd:v6.10.0
+    container_name: zcashd-testnet
+    restart: always
+    ports:
+      - "${ZCASHD_TESTNET_RPC_PORT:-18232}:18232"
+      - "${ZCASHD_TESTNET_P2P_PORT:-18233}:18233"
+    volumes:
+      - ${DATA_DIR}/zcashd_testnet_data:/srv/zcashd/.zcash
+    networks:
+      - zcash-network
+
+  lightwalletd-testnet:
+    image: electriccoinco/lightwalletd:v0.4.18
+    container_name: lightwalletd-testnet
+    restart: always
+    depends_on:
+      - zcashd-testnet
+    ports:
+      - "${LIGHTWALLETD_TESTNET_PORT:-19067}:9067"
+    volumes:
+      - ${DATA_DIR}/lightwalletd_testnet_db:/srv/lightwalletd/db_volume
+    networks:
+      - zcash-network
+    command: >
+      --grpc-bind-addr 0.0.0.0:9067 --no-tls-very-insecure --rpchost
+      zcashd-testnet --rpcport 18232 --rpcuser ${LIGHTWALLETD_RPC_USER}
+      --rpcpassword ${LIGHTWALLETD_RPC_PASSWORD} --data-dir
+      /srv/lightwalletd/db_volume --log-file /dev/stdout
+
+networks:
+  zcash-network:
+    external: true
+    name: zcash-network

--- a/docker-compose.zebra.testnet.yml
+++ b/docker-compose.zebra.testnet.yml
@@ -1,0 +1,35 @@
+# Zebra Testnet Configuration
+
+services:
+  zebra-testnet:
+    image: zfnd/zebra:3.1.0
+    container_name: zebra-testnet
+    restart: always
+    ports:
+      - "${ZEBRA_TESTNET_RPC_PORT:-18232}:8232"
+      - "${ZEBRA_TESTNET_P2P_PORT:-18233}:8233"
+    volumes:
+      - ${DATA_DIR}/zebrad-testnet-cache:/home/zebra/.cache/zebra
+      - ./zebrad.testnet.toml:/etc/zebrad/zebrad.toml:ro
+    networks:
+      - zcash-network
+
+  zaino-testnet:
+    image: zingolabs/zaino:latest
+    container_name: zaino-testnet
+    restart: always
+    depends_on:
+      - zebra-testnet
+    ports:
+      - "${ZAINO_TESTNET_GRPC_PORT:-18137}:8137"
+    volumes:
+      - ./zaino.testnet.toml:/etc/zaino/zaino.toml:ro
+      - ${DATA_DIR}/zaino-testnet-data:/home/container_user/.cache/zaino
+    networks:
+      - zcash-network
+    command: ["zainod", "--config", "/etc/zaino/zaino.toml"]
+
+networks:
+  zcash-network:
+    external: true
+    name: zcash-network

--- a/docker-compose.zebra.testnet.yml
+++ b/docker-compose.zebra.testnet.yml
@@ -13,7 +13,7 @@ services:
       - ./zebrad.testnet.toml:/etc/zebrad/zebrad.toml:ro
     networks:
       - zcash-network
-    command: ["-c", "/etc/zebrad/zebrad.toml", "start"]
+    entrypoint: ["zebrad", "-c", "/etc/zebrad/zebrad.toml", "start"]
 
   zaino-testnet:
     image: zingolabs/zaino:latest

--- a/docker-compose.zebra.testnet.yml
+++ b/docker-compose.zebra.testnet.yml
@@ -13,6 +13,7 @@ services:
       - ./zebrad.testnet.toml:/etc/zebrad/zebrad.toml:ro
     networks:
       - zcash-network
+    command: ["-c", "/etc/zebrad/zebrad.toml", "start"]
 
   zaino-testnet:
     image: zingolabs/zaino:latest

--- a/docker-compose.zebra.yml
+++ b/docker-compose.zebra.yml
@@ -14,7 +14,7 @@ services:
       - ./zebrad.toml:/etc/zebrad/zebrad.toml:ro
     networks:
       - zcash-network
-    command: ["-c", "/etc/zebrad/zebrad.toml", "start"]
+    entrypoint: ["zebrad", "-c", "/etc/zebrad/zebrad.toml", "start"]
 
   zaino:
     image: zingolabs/zaino:latest # Build with 'make build-zaino' or specify commit with 'make update-zaino-commit COMMIT=<hash>'

--- a/docker-compose.zebra.yml
+++ b/docker-compose.zebra.yml
@@ -14,6 +14,7 @@ services:
       - ./zebrad.toml:/etc/zebrad/zebrad.toml:ro
     networks:
       - zcash-network
+    command: ["-c", "/etc/zebrad/zebrad.toml", "start"]
 
   zaino:
     image: zingolabs/zaino:latest # Build with 'make build-zaino' or specify commit with 'make update-zaino-commit COMMIT=<hash>'

--- a/zaino.toml.testnet.template
+++ b/zaino.toml.testnet.template
@@ -1,0 +1,18 @@
+network = "Testnet"
+grpc_listen_address = "0.0.0.0:ZAINO_GRPC_PORT"
+grpc_tls = false
+tls_cert_path = "None"
+tls_key_path = "None"
+# Connect to zebra-testnet container
+validator_listen_address = "zebra-testnet:ZEBRA_RPC_PORT"
+validator_cookie_auth = false
+validator_cookie_path = "None"
+validator_user = "None"
+validator_password = "None"
+map_capacity = "None"
+map_shard_amount = "None"
+db_path = "/home/zaino/.cache/zaino"
+db_size = "None"
+no_sync = false
+no_db = true
+no_state = false

--- a/zcash.conf.testnet.template
+++ b/zcash.conf.testnet.template
@@ -1,0 +1,46 @@
+# Zcash Testnet Configuration File
+# This file will be copied into zcash.conf when running `make start-zcash-testnet`
+
+# Enable testnet
+testnet=1
+
+# Network Configuration
+listen=1
+bind=0.0.0.0
+rpcbind=0.0.0.0
+rpcallowip=0.0.0.0/0
+
+# RPC Authentication (use values from .env file)
+rpcuser=LIGHTWALLETD_RPC_USER
+rpcpassword=LIGHTWALLETD_RPC_PASSWORD
+
+# P2P Network Configuration
+maxconnections=125
+
+# Testnet seed nodes
+addnode=testnet.z.cash
+addnode=dnsseed.testnet.z.cash
+
+# Performance Optimization
+dbcache=450
+maxuploadtarget=1000
+maxreceivebuffer=2500
+maxsendbuffer=500
+
+# Transaction Index
+txindex=0
+
+# Wallet Options
+disablewallet=0
+
+# Security Settings
+gen=0
+
+# Logging
+shrinkdebugfile=1
+
+# Checkpoint verification
+checkblocks=24
+checklevel=4
+
+i-am-aware-zcashd-will-be-replaced-by-zebrad-and-zallet-in-2025=1

--- a/zebrad.toml.testnet.template
+++ b/zebrad.toml.testnet.template
@@ -1,0 +1,14 @@
+[network]
+network = "Testnet"
+listen_addr = "0.0.0.0:ZEBRA_P2P_PORT"
+
+[state]
+cache_dir = "/var/cache/zebrad-cache"
+
+[rpc]
+listen_addr = "0.0.0.0:ZEBRA_RPC_PORT"
+enable_cookie_auth = false
+parallel_cpu_threads = 0
+
+[tracing]
+use_color = false


### PR DESCRIPTION
## Summary
- Add testnet configuration templates for zebrad, zaino, and zcashd
- Add docker-compose files for testnet services with separate containers
- Add Makefile targets for testnet operations

## New Targets
- `make setup-testnet` - Create testnet directories and config files
- `make start-zcash-testnet` - Start zcashd-testnet + lightwalletd-testnet
- `make start-zebra-testnet` - Start zebra-testnet + zaino-testnet
- `make stop-zcash-testnet` - Stop Zcash testnet services
- `make stop-zebra-testnet` - Stop Zebra testnet services

## Testnet Ports
| Service | Mainnet | Testnet |
|---------|---------|---------|
| zcashd RPC | 8232 | 18232 |
| zcashd P2P | 8233 | 18233 |
| zebra RPC | 8232 | 18232 |
| zebra P2P | 8233 | 18233 |
| lightwalletd | 9067 | 19067 |
| zaino | 8137 | 18137 |

Closes #13

## Test plan
- [ ] Run `make setup-testnet`
- [ ] Run `make start-zebra-testnet`
- [ ] Verify testnet containers start correctly